### PR TITLE
add QSTAT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ keywords = [ "disque", "message", "broker", "scheduling", "distributed" ]
 license-file = "LICENSE"
 
 [dependencies]
-redis = "0.5.0"
+redis = "0.5.4"

--- a/src/disque.rs
+++ b/src/disque.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use redis::{Connection, RedisError, cmd, Value, ErrorKind, FromRedisValue,
+use redis::{Connection, RedisError, cmd, Value, ErrorKind,
     IntoConnectionInfo, Iter, RedisResult, InfoDict, Client};
+
+pub use redis::FromRedisValue;
 
 fn duration_to_millis(d: &Duration) -> u64 {
     (d.subsec_nanos() / 1_000_000) as u64 + d.as_secs()
@@ -336,6 +338,9 @@ impl Disque {
         }
         c.arg("REPLY").arg("all");
         c.cursor_arg(cursor).iter(&self.connection)
+    }
+    pub fn qstat(&self, queue_name: &[u8]) -> RedisResult<HashMap<String, Value>> {
+        cmd("QSTAT").arg(queue_name).query(&self.connection)
     }
 }
 


### PR DESCRIPTION
We're still using disque, and wanted to add some basic prometheus metrics. So when writing a [disque exporter](https://github.com/kaspar030/disque-exporter), I realized there was no qstat support.

So here it is.